### PR TITLE
Upgrade to a better version

### DIFF
--- a/fsplit/__init__.py
+++ b/fsplit/__init__.py
@@ -8,5 +8,5 @@
 # Licensed under the MIT license.
 ##
 
-from info import __version__ # define __version__ variable
-from info import __desc__ # define __desc__ variable for description
+from .info import __version__ # define __version__ variable
+from .info import __desc__ # define __desc__ variable for description


### PR DESCRIPTION
from info import __version__ # define __version__ variable         ModuleNotFoundError: No module named 'info

Gave error while building 
Coz of missing .